### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This project adheres to the Contributor [code of conduct](CODE_OF_CONDUCT.md). B
 
 ## Documentation (WIP)
 
-* The full documentation is available at: [https://pollen-robotics.github.io/reachy-docs/](https://pollen-robotics.github.io/reachy-docs/)
-* The APIs can be found at: [https://pollen-robotics.github.io/reachy/](https://pollen-robotics.github.io/reachy/)
+* The full documentation is available at: [https://pollen-robotics.github.io/reachy-2019-docs/](https://pollen-robotics.github.io/reachy-2019-docs/)
+* The APIs can be found at: [https://pollen-robotics.github.io/reachy-2019/](https://pollen-robotics.github.io/reachy-2019/)
 
 ## Installation
 


### PR DESCRIPTION
### Identify the Bug (if you are fixing one)

Links to reachy docs and reachy api are broken.

### Description of the Change

Need to update the links to

https://pollen-robotics.github.io/reachy-2019-docs
https://pollen-robotics.github.io/reachy-2019

### Possible Drawbacks

None

### Release Notes

Fixed broken links to reachy docs page and reachy api page.